### PR TITLE
fix for the properties category error

### DIFF
--- a/src/components/Cta.svelte
+++ b/src/components/Cta.svelte
@@ -19,7 +19,7 @@
       report = 'Booking was successful. We will contact you shortly'
     }).catch((error) =>{
       loading = false
-      error = 'An error occured. Please try booking again'
+      error = 'An error occurred. Please try booking again'
       console.error(error)
     })
   }
@@ -45,7 +45,7 @@
         </span>
         <label class="block">
           <span class="mb-1 text-white sm:text-black">Full name</span>
-          <input type="text" placeholder="Leroy Jenkins" class="block w-full rounded-md shadow-sm focus:ring focus:ring-opacity-75 focus:ring-indigo-400" bind:value={name} required name="name" autocomplete="name">
+          <input type="text" placeholder="Amani James" class="block w-full rounded-md shadow-sm focus:ring focus:ring-opacity-75 focus:ring-indigo-400" bind:value={name} required name="name" autocomplete="name">
         </label>
         <label class="block">
           <span class="mb-1 text-white sm:text-black">Phone Number</span>
@@ -53,7 +53,7 @@
         </label>
         <label class="block">
           <span class="mb-1 text-white sm:text-black">Email address</span>
-          <input type="email" placeholder="leroy@jenkins.com" class="block w-full rounded-md shadow-sm focus:ring focus:ring-opacity-75 focus:ring-indigo-400" bind:value={email} required name="email" autocomplete="email">
+          <input type="email" placeholder="amanijames@gmail.com" class="block w-full rounded-md shadow-sm focus:ring focus:ring-opacity-75 focus:ring-indigo-400" bind:value={email} required name="email" autocomplete="email">
         </label>
         {#if !report}
           {#if loading}

--- a/src/pages/properties/index.astro
+++ b/src/pages/properties/index.astro
@@ -8,49 +8,61 @@ const data = await res.json()
 ---
 
 <Layout title="Land for sale in Malindi - AHL Properties" description="">
+	<!-- Banner Section -->
 	<section class="bg-blue-800 h-[36em] w-full bg-cover bg-black bg-opacity-80" style="background-image: url('/images/banner-1.jpg');">
-		<h1 class="text-white text-6xl pt-72 text-center font-bold uppercase">
-			Properties
-		</h1>
+	  <h1 class="text-white text-6xl pt-72 text-center font-bold uppercase">
+		Properties
+	  </h1>
 	</section>
+	
+	<!-- Properties Grid Section -->
 	<section class="py-6 mb-2 -mt-24 container mx-auto">
-		<div class="grid sm:grid-cols-2 gap-6">
-			{
-				data.map((item) => (
-					<a href={`/properties/${item.slug}`} class="block rounded-lg p-4 bg-white shadow-sm">
-					  <img alt={item.acf.property_name} src={item._embedded["wp:featuredmedia"][0].media_details.sizes.large.source_url} class="h-56 w-full rounded-md object-cover" />
-					  <p class="text-xl text-center mt-2 uppercase text-blue-800">
-					  	{item.acf.property_location}
-					  </p>
-					  <h2 class="text-4xl text-center mt-2 uppercase text-blue-800 font-serif">
-					  	{item.acf.property_name}
-					  </h2>
-					  <p class="text-gray-600 mt-2">
-					  	{item.acf.property_brief_description}
-					  </p>
-					  <div class="grid grid-cols-2 gap-4 divide-x-2">
-					  	<div class="flex flex-col">
-					  		<p class="text-gray-600 mt-2 text-lg uppercase text-center">
-					  			Total Cost
-					  		</p>
-					  		<button class="p-2 font-black">
-					  			{item.acf.property_price}
-					  		</button>
-					  	</div>
-					  	<div class="flex flex-col">
-					  		<p class="text-gray-600 mt-2 text-lg uppercase text-center">
-					  			Booking Fee
-					  		</p>
-					  		<button class="p-2 font-black">
-					  			{item.acf.property_booking_fee}
-					  		</button>
-					  	</div>
-					  	<button class="bg-yellow-600 p-2 text-white col-span-2">View Property</button>
-					  </div>
-					</a>
-				))
-			}
-		</div>
+	  <div class="grid sm:grid-cols-2 gap-6">
+		{
+		  data.map((item) => {
+			// Check if the featured image is available
+			const hasImage = item._embedded && item._embedded["wp:featuredmedia"] && item._embedded["wp:featuredmedia"][0] && item._embedded["wp:featuredmedia"][0].media_details && item._embedded["wp:featuredmedia"][0].media_details.sizes.large.source_url;
+			const imageUrl = hasImage ? item._embedded["wp:featuredmedia"][0].media_details.sizes.large.source_url : '/images/sample-1.jpg'; // Fallback image URL
+  
+			return (
+			  <a href={`/properties/${item.slug}`} class="block rounded-lg p-4 bg-white shadow-sm">
+				<img alt={item.acf.property_name} src={imageUrl} class="h-56 w-full rounded-md object-cover" />
+				<p class="text-xl text-center mt-2 uppercase text-blue-800">
+				  {item.acf.property_location}
+				</p>
+				<h2 class="text-4xl text-center mt-2 uppercase text-blue-800 font-serif">
+				  {item.acf.property_name}
+				</h2>
+				<p class="text-gray-600 mt-2">
+				  {item.acf.property_brief_description}
+				</p>
+				<div class="grid grid-cols-2 gap-4 divide-x-2">
+				  <div class="flex flex-col">
+					<p class="text-gray-600 mt-2 text-lg uppercase text-center">
+					  Total Cost
+					</p>
+					<button class="p-2 font-black">
+					  {item.acf.property_price}
+					</button>
+				  </div>
+				  <div class="flex flex-col">
+					<p class="text-gray-600 mt-2 text-lg uppercase text-center">
+					  Booking Fee
+					</p>
+					<button class="p-2 font-black">
+					  {item.acf.property_booking_fee}
+					</button>
+				  </div>
+				  <button class="bg-yellow-600 p-2 text-white col-span-2">View Property</button>
+				</div>
+			  </a>
+			);
+		  })
+		}
+	  </div>
 	</section>
-	<Cta client:load  />
-</Layout>
+	
+	<!-- Call to Action Section -->
+	<Cta client:load />
+  </Layout>
+  


### PR DESCRIPTION
feat(properties): handle missing featured images with a fallback

This update ensures that the properties page gracefully handles cases where a featured image is not available in the fetched data. Changes include:

- Added a check to verify if the featured image exists for each property.
- Provided a default fallback image (`/images/sample-1.jpg`) to be used when a featured image is missing.
- Updated property card component to use the fallback image if necessary.

This enhancement improves the user experience by preventing broken images and maintaining a consistent layout.

